### PR TITLE
Restored the tests and added tests for model serializer_class method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# LegacySerializer, derived from ActiveModel::Serializers
+# LegacySerializer, derived from LegacySerializer::Serializers
 
 [![Build Status](https://travis-ci.org/rails-api/active_model_serializers.svg)](https://travis-ci.org/rails-api/active_model_serializers)
 
-ActiveModel::Serializers brings convention over configuration to your JSON generation.
+LegacySerializer::Serializers brings convention over configuration to your JSON generation.
 
 AMS does this through two components: **serializers** and **adapters**. Serializers describe which attributes and relationships should be serialized. Adapters describe how attributes and relationships should be serialized.
 
@@ -32,7 +32,7 @@ Given two models, a `Post(title: string, body: text)` and a
 serializers:
 
 ```ruby
-class PostSerializer < ActiveModel::Serializer
+class PostSerializer < LegacySerializer::Serializer
   attributes :title, :body
 
   has_many :comments
@@ -44,7 +44,7 @@ end
 and
 
 ```ruby
-class CommentSerializer < ActiveModel::Serializer
+class CommentSerializer < LegacySerializer::Serializer
   attributes :name, :body
 
   belongs_to :post
@@ -59,13 +59,13 @@ by AMS. If you want to use a different adapter, such as a HalAdapter, you can
 change this in an initializer:
 
 ```ruby
-ActiveModel::Serializer.config.adapter = ActiveModel::Serializer::Adapter::HalAdapter
+LegacySerializer::Serializer.config.adapter = LegacySerializer::Serializer::Adapter::HalAdapter
 ```
 
 or
 
 ```ruby
-ActiveModel::Serializer.config.adapter = :hal
+LegacySerializer::Serializer.config.adapter = :hal
 ```
 
 You won't need to implement an adapter unless you wish to use a new format or
@@ -74,7 +74,7 @@ media type with AMS.
 If you would like the key in the outputted JSON to be different from its name in ActiveRecord, you can use the :key option to customize it:
 
 ```ruby
-class PostSerializer < ActiveModel::Serializer
+class PostSerializer < LegacySerializer::Serializer
   attributes :id, :body
 
   # look up :subject on the model, but use +title+ in the JSON
@@ -164,7 +164,7 @@ The generated seralizer will contain basic `attributes` and
 `has_many`/`belongs_to` declarations, based on the model. For example:
 
 ```ruby
-class PostSerializer < ActiveModel::Serializer
+class PostSerializer < LegacySerializer::Serializer
   attributes :title, :body
 
   has_many :comments
@@ -176,7 +176,7 @@ end
 and
 
 ```ruby
-class CommentSerializer < ActiveModel::Serializer
+class CommentSerializer < LegacySerializer::Serializer
   attributes :name, :body
 
   belongs_to :post_id

--- a/lib/legacy_serializer/serializer.rb
+++ b/lib/legacy_serializer/serializer.rb
@@ -156,22 +156,11 @@ module LegacySerializer
     private
 
     def self.get_serializer_for(klass)
-#      serializer_class = if klass.respond_to?(:serializer_class)
-#        klass.serializer_class
-#      else
-#        serializer_class_name = "#{klass.name}Serializer"
-#        serializer_class_name.safe_constantize
-#      end
-      #serializer_class = if klass.to_s.starts_with?("Samples") #.split("::").first == "Samples" # klass != NilClass && klass != Object && klass != BasicObject
-      #  klass.serializer_class
-      #else
-      #  serializer_class_name = "#{klass.name}Serializer"
-      #  serializer_class_name.safe_constantize
-      #end
-
       serializer_class = if klass.respond_to?(:serializer_class)
-        klass.serializer_class
-      end
+                           klass.serializer_class
+                         else
+                           "#{klass.name}Serializer".safe_constantize
+                         end
 
       if serializer_class
         serializer_class

--- a/test/adapter/json/belongs_to_test.rb
+++ b/test/adapter/json/belongs_to_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+
+module LegacySerializer
+  class Serializer
+    class Adapter
+      class Json
+        class BelongsToTest < Minitest::Test
+          def setup
+            @post = Post.new(id: 42, title: 'New Post', body: 'Body')
+            @anonymous_post = Post.new(id: 43, title: 'Hello!!', body: 'Hello, world!!')
+            @comment = Comment.new(id: 1, body: 'ZOMG A COMMENT')
+            @post.comments = [@comment]
+            @anonymous_post.comments = []
+            @post.author = @author
+            @comment.post = @post
+            @comment.author = nil
+            @anonymous_post.author = nil
+
+            @serializer = CommentSerializer.new(@comment)
+            @adapter = LegacySerializer::Serializer::Adapter::Json.new(@serializer)
+          end
+
+          def test_includes_post
+            assert_equal({id: 42, title: 'New Post', body: 'Body'}, @adapter.serializable_hash[:post])
+          end
+
+          def test_include_nil_author
+            serializer = PostSerializer.new(@anonymous_post)
+            adapter = LegacySerializer::Serializer::Adapter::Json.new(serializer)
+
+            assert_equal({title: "Hello!!", body: "Hello, world!!", id: 43, comments: [], author: nil}, adapter.serializable_hash)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/adapter/json/collection_test.rb
+++ b/test/adapter/json/collection_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+module LegacySerializer
+  class Serializer
+    class Adapter
+      class Json
+        class Collection < Minitest::Test
+          def setup
+            @author = Author.new(id: 1, name: 'Steve K.')
+            @first_post = Post.new(id: 1, title: 'Hello!!', body: 'Hello, world!!')
+            @second_post = Post.new(id: 2, title: 'New Post', body: 'Body')
+            @first_post.comments = []
+            @second_post.comments = []
+            @first_post.author = @author
+            @second_post.author = @author
+
+            @serializer = ArraySerializer.new([@first_post, @second_post])
+            @adapter = LegacySerializer::Serializer::Adapter::Json.new(@serializer)
+          end
+
+          def test_include_multiple_posts
+            assert_equal([
+                           {title: "Hello!!", body: "Hello, world!!", id: 1, comments: [], author: {id: 1, name: "Steve K."}},
+                           {title: "New Post", body: "Body", id: 2, comments: [], author: {id: 1, name: "Steve K."}}
+                         ], @adapter.serializable_hash)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/adapter/json/has_many_test.rb
+++ b/test/adapter/json/has_many_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+
+module LegacySerializer
+  class Serializer
+    class Adapter
+      class Json
+        class HasManyTestTest < Minitest::Test
+          def setup
+            @author = Author.new(id: 1, name: 'Steve K.')
+            @post = Post.new(title: 'New Post', body: 'Body')
+            @first_comment = Comment.new(id: 1, body: 'ZOMG A COMMENT')
+            @second_comment = Comment.new(id: 2, body: 'ZOMG ANOTHER COMMENT')
+            @post.comments = [@first_comment, @second_comment]
+            @post.author = @author
+            @first_comment.post = @post
+            @second_comment.post = @post
+
+            @serializer = PostSerializer.new(@post)
+            @adapter = LegacySerializer::Serializer::Adapter::Json.new(@serializer)
+          end
+
+          def test_has_many
+            assert_equal([
+                           {id: 1, body: 'ZOMG A COMMENT'},
+                           {id: 2, body: 'ZOMG ANOTHER COMMENT'}
+                         ], @adapter.serializable_hash[:comments])
+          end
+        end
+      end
+    end
+  end
+end
+

--- a/test/adapter/json_api/belongs_to_test.rb
+++ b/test/adapter/json_api/belongs_to_test.rb
@@ -1,0 +1,110 @@
+require 'test_helper'
+
+module LegacySerializer
+  class Serializer
+    class Adapter
+      class JsonApi
+        class BelongsToTest < Minitest::Test
+          def setup
+            @author = Author.new(id: 1, name: 'Steve K.')
+            @author.bio = nil
+            @author.roles = []
+            @post = Post.new(id: 42, title: 'New Post', body: 'Body')
+            @anonymous_post = Post.new(id: 43, title: 'Hello!!', body: 'Hello, world!!')
+            @comment = Comment.new(id: 1, body: 'ZOMG A COMMENT')
+            @post.comments = [@comment]
+            @anonymous_post.comments = []
+            @comment.post = @post
+            @comment.author = nil
+            @post.author = @author
+            @anonymous_post.author = nil
+            @blog = Blog.new(id: 1, name: "My Blog!!")
+            @blog.writer = @author
+            @blog.articles = [@post, @anonymous_post]
+            @author.posts = []
+
+            @serializer = CommentSerializer.new(@comment)
+            @adapter = LegacySerializer::Serializer::Adapter::JsonApi.new(@serializer)
+          end
+
+          def test_includes_post_id
+            assert_equal("42", @adapter.serializable_hash[:comments][:links][:post])
+          end
+
+          def test_includes_linked_post
+            @adapter = LegacySerializer::Serializer::Adapter::JsonApi.new(@serializer, include: 'post')
+            expected = [{
+              id: "42",
+              title: 'New Post',
+              body: 'Body',
+              links: {
+                comments: ["1"],
+                author: "1"
+              }
+            }]
+            assert_equal expected, @adapter.serializable_hash[:linked][:posts]
+          end
+
+          def test_include_nil_author
+            serializer = PostSerializer.new(@anonymous_post)
+            adapter = LegacySerializer::Serializer::Adapter::JsonApi.new(serializer)
+
+            assert_equal({comments: [], author: nil}, adapter.serializable_hash[:posts][:links])
+          end
+
+          def test_include_type_for_association_when_is_different_than_name
+            serializer = BlogSerializer.new(@blog)
+            adapter = LegacySerializer::Serializer::Adapter::JsonApi.new(serializer)
+            links = adapter.serializable_hash[:blogs][:links]
+            expected = {
+              writer: {
+                type: "author",
+                id: "1"
+              },
+              articles: {
+                type: "posts",
+                ids: ["42", "43"]
+              }
+            }
+            assert_equal expected, links
+          end
+
+          def test_include_linked_resources_with_type_name
+            serializer = BlogSerializer.new(@blog)
+            adapter = LegacySerializer::Serializer::Adapter::JsonApi.new(serializer, include: "writer,articles")
+            linked = adapter.serializable_hash[:linked]
+            expected = {
+              authors: [{
+                id: "1",
+                name: "Steve K.",
+                links: {
+                  posts: [],
+                  roles: [],
+                  bio: nil
+                }
+              }],
+              posts: [{
+                title: "New Post",
+                body: "Body",
+                id: "42",
+                links: {
+                  comments: ["1"],
+                  author: "1"
+                }
+              }, {
+                title: "Hello!!",
+                body: "Hello, world!!",
+                id: "43",
+                links: {
+                  comments: [],
+                  author: nil
+                }
+              }]
+            }
+            assert_equal expected, linked
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/adapter/json_api/collection_test.rb
+++ b/test/adapter/json_api/collection_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+
+module LegacySerializer
+  class Serializer
+    class Adapter
+      class JsonApi
+        class CollectionTest < Minitest::Test
+          def setup
+            @author = Author.new(id: 1, name: 'Steve K.')
+            @author.bio = nil
+            @first_post = Post.new(id: 1, title: 'Hello!!', body: 'Hello, world!!')
+            @second_post = Post.new(id: 2, title: 'New Post', body: 'Body')
+            @first_post.comments = []
+            @second_post.comments = []
+            @first_post.author = @author
+            @second_post.author = @author
+            @author.posts = [@first_post, @second_post]
+
+            @serializer = ArraySerializer.new([@first_post, @second_post])
+            @adapter = LegacySerializer::Serializer::Adapter::JsonApi.new(@serializer)
+          end
+
+          def test_include_multiple_posts
+            assert_equal([
+                           { title: "Hello!!", body: "Hello, world!!", id: "1", links: { comments: [], author: "1" } },
+                           { title: "New Post", body: "Body", id: "2", links: { comments: [], author: "1" } }
+                         ], @adapter.serializable_hash[:posts])
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/adapter/json_api/has_many_embed_ids_test.rb
+++ b/test/adapter/json_api/has_many_embed_ids_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+module LegacySerializer
+  class Serializer
+    class Adapter
+      class JsonApi
+        class HasManyEmbedIdsTest < Minitest::Test
+          def setup
+            @author = Author.new(name: 'Steve K.')
+            @author.bio = nil
+            @author.roles = nil
+            @first_post = Post.new(id: 1, title: 'Hello!!', body: 'Hello, world!!')
+            @second_post = Post.new(id: 2, title: 'New Post', body: 'Body')
+            @author.posts = [@first_post, @second_post]
+            @first_post.author = @author
+            @second_post.author = @author
+            @first_post.comments = []
+            @second_post.comments = []
+
+            @serializer = AuthorSerializer.new(@author)
+            @adapter = LegacySerializer::Serializer::Adapter::JsonApi.new(@serializer)
+          end
+
+          def test_includes_comment_ids
+            assert_equal(["1", "2"], @adapter.serializable_hash[:authors][:links][:posts])
+          end
+
+          def test_no_includes_linked_comments
+            assert_nil @adapter.serializable_hash[:linked]
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/adapter/json_api/has_many_test.rb
+++ b/test/adapter/json_api/has_many_test.rb
@@ -1,0 +1,72 @@
+require 'test_helper'
+
+module LegacySerializer
+  class Serializer
+    class Adapter
+      class JsonApi
+        class HasManyTest < Minitest::Test
+          def setup
+            @author = Author.new(id: 1, name: 'Steve K.')
+            @author.posts = []
+            @author.bio = nil
+            @post = Post.new(id: 1, title: 'New Post', body: 'Body')
+            @post_without_comments = Post.new(id: 2, title: 'Second Post', body: 'Second')
+            @first_comment = Comment.new(id: 1, body: 'ZOMG A COMMENT')
+            @first_comment.author = nil
+            @second_comment = Comment.new(id: 2, body: 'ZOMG ANOTHER COMMENT')
+            @second_comment.author = nil
+            @post.comments = [@first_comment, @second_comment]
+            @post_without_comments.comments = []
+            @first_comment.post = @post
+            @second_comment.post = @post
+            @post.author = @author
+            @post_without_comments.author = nil
+            @blog = Blog.new(id: 1, name: "My Blog!!")
+            @blog.writer = @author
+            @blog.articles = [@post]
+
+            @serializer = PostSerializer.new(@post)
+            @adapter = LegacySerializer::Serializer::Adapter::JsonApi.new(@serializer)
+          end
+
+          def test_includes_comment_ids
+            assert_equal(["1", "2"], @adapter.serializable_hash[:posts][:links][:comments])
+          end
+
+          def test_includes_linked_comments
+            @adapter = LegacySerializer::Serializer::Adapter::JsonApi.new(@serializer, include: 'comments')
+            expected = [{
+              id: "1",
+              body: 'ZOMG A COMMENT',
+              links: {
+                post: "1",
+                author: nil
+              }
+            }, {
+              id: "2",
+              body: 'ZOMG ANOTHER COMMENT',
+              links: {
+                post: "1",
+                author: nil
+              }
+            }]
+            assert_equal expected, @adapter.serializable_hash[:linked][:comments]
+          end
+
+          def test_no_include_linked_if_comments_is_empty
+            serializer = PostSerializer.new(@post_without_comments)
+            adapter = LegacySerializer::Serializer::Adapter::JsonApi.new(serializer)
+
+            assert_nil adapter.serializable_hash[:linked]
+          end
+
+          def test_include_type_for_association_when_is_different_than_name
+            serializer = BlogSerializer.new(@blog)
+            adapter = LegacySerializer::Serializer::Adapter::JsonApi.new(serializer)
+            assert_equal({type: "posts", ids: ["1"]}, adapter.serializable_hash[:blogs][:links][:articles])
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/adapter/json_api/linked_test.rb
+++ b/test/adapter/json_api/linked_test.rb
@@ -1,0 +1,145 @@
+require 'test_helper'
+
+module LegacySerializer
+  class Serializer
+    class Adapter
+      class JsonApi
+        class LinkedTest < Minitest::Test
+          def setup
+            @author1 = Author.new(id: 1, name: 'Steve K.')
+            @author2 = Author.new(id: 2, name: 'Tenderlove')
+            @bio1 = Bio.new(id: 1, content: 'AMS Contributor')
+            @bio2 = Bio.new(id: 2, content: 'Rails Contributor')
+            @first_post = Post.new(id: 1, title: 'Hello!!', body: 'Hello, world!!')
+            @second_post = Post.new(id: 2, title: 'New Post', body: 'Body')
+            @third_post = Post.new(id: 3, title: 'Yet Another Post', body: 'Body')
+            @first_post.comments = []
+            @second_post.comments = []
+            @first_post.author = @author1
+            @second_post.author = @author2
+            @third_post.author = @author1
+            @author1.posts = [@first_post, @third_post]
+            @author1.bio = @bio1
+            @author1.roles = []
+            @author2.posts = [@second_post]
+            @author2.bio = @bio2
+            @author2.roles = []
+            @bio1.author = @author1
+            @bio2.author = @author2
+          end
+
+          def test_include_multiple_posts_and_linked
+            @serializer = ArraySerializer.new([@first_post, @second_post])
+            @adapter = LegacySerializer::Serializer::Adapter::JsonApi.new(@serializer, include: 'author,author.bio,comments')
+
+            @first_comment = Comment.new(id: 1, body: 'ZOMG A COMMENT')
+            @second_comment = Comment.new(id: 2, body: 'ZOMG ANOTHER COMMENT')
+            @first_post.comments = [@first_comment, @second_comment]
+            @first_comment.post = @first_post
+            @first_comment.author = nil
+            @second_comment.post = @first_post
+            @second_comment.author = nil
+            assert_equal([
+                           { title: "Hello!!", body: "Hello, world!!", id: "1", links: { comments: ['1', '2'], author: "1" } },
+                           { title: "New Post", body: "Body", id: "2", links: { comments: [], :author => "2" } }
+                         ], @adapter.serializable_hash[:posts])
+
+
+            expected = {
+              comments: [{
+                id: "1",
+                body: "ZOMG A COMMENT",
+                links: {
+                  post: "1",
+                  author: nil
+                }
+              }, {
+                id: "2",
+                body: "ZOMG ANOTHER COMMENT",
+                links: {
+                  post: "1",
+                  author: nil
+                }
+              }],
+              authors: [{
+                id: "1",
+                name: "Steve K.",
+                links: {
+                  posts: ["1"],
+                  roles: [],
+                  bio: "1"
+                }
+              }, {
+                id: "2",
+                name: "Tenderlove",
+                links: {
+                  posts: ["2"],
+                  roles: [],
+                  bio: "2"
+                }
+              }],
+              bios: [{
+                id: "1",
+                content: "AMS Contributor",
+                links: {
+                  author: "1"
+                }
+              }, {
+                id: "2",
+                content: "Rails Contributor",
+                links: {
+                  author: "2"
+                }
+              }]
+            }
+            assert_equal expected, @adapter.serializable_hash[:linked]
+          end
+
+          def test_include_multiple_posts_and_linked
+            @serializer = BioSerializer.new(@bio1)
+            @adapter = LegacySerializer::Serializer::Adapter::JsonApi.new(@serializer, include: 'author,author.posts')
+
+            @first_comment = Comment.new(id: 1, body: 'ZOMG A COMMENT')
+            @second_comment = Comment.new(id: 2, body: 'ZOMG ANOTHER COMMENT')
+            @first_post.comments = [@first_comment, @second_comment]
+            @third_post.comments = []
+            @first_comment.post = @first_post
+            @first_comment.author = nil
+            @second_comment.post = @first_post
+            @second_comment.author = nil
+
+            expected = {
+              authors: [{
+                id: "1",
+                name: "Steve K.",
+                links: {
+                  posts: ["1", "3"],
+                  roles: [],
+                  bio: "1"
+                }
+              }],
+              posts: [{
+                title: "Hello!!",
+                body: "Hello, world!!",
+                id: "1",
+                links: {
+                  comments: ["1", "2"],
+                  author: "1"
+                }
+              }, {
+                title: "Yet Another Post",
+                body: "Body",
+                id: "3",
+                links: {
+                  comments: [],
+                  author: "1"
+                }
+              }]
+            }
+            assert_equal expected, @adapter.serializable_hash[:linked]
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/adapter/json_test.rb
+++ b/test/adapter/json_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+module LegacySerializer
+  class Serializer
+    class Adapter
+      class JsonTest < Minitest::Test
+        def setup
+          @author = Author.new(id: 1, name: 'Steve K.')
+          @post = Post.new(title: 'New Post', body: 'Body')
+          @first_comment = Comment.new(id: 1, body: 'ZOMG A COMMENT')
+          @second_comment = Comment.new(id: 2, body: 'ZOMG ANOTHER COMMENT')
+          @post.comments = [@first_comment, @second_comment]
+          @first_comment.post = @post
+          @second_comment.post = @post
+          @post.author = @author
+
+          @serializer = PostSerializer.new(@post)
+          @adapter = LegacySerializer::Serializer::Adapter::Json.new(@serializer)
+        end
+
+        def test_has_many
+          assert_equal([
+                         {id: 1, body: 'ZOMG A COMMENT'},
+                         {id: 2, body: 'ZOMG ANOTHER COMMENT'}
+                       ], @adapter.serializable_hash[:comments])
+        end
+      end
+    end
+  end
+end
+

--- a/test/adapter/null_test.rb
+++ b/test/adapter/null_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+module LegacySerializer
+  class Serializer
+    class Adapter
+      class NullTest < Minitest::Test
+        def setup
+          profile = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
+          serializer = ProfileSerializer.new(profile)
+
+          @adapter = Null.new(serializer)
+        end
+
+        def test_serializable_hash
+          assert_equal({}, @adapter.serializable_hash)
+        end
+
+        def test_it_returns_empty_json
+          assert_equal('{}', @adapter.to_json)
+        end
+      end
+    end
+  end
+end
+

--- a/test/adapter_test.rb
+++ b/test/adapter_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+
+module LegacySerializer
+  class Serializer
+    class AdapterTest < Minitest::Test
+      def setup
+        profile = Profile.new
+        @serializer = ProfileSerializer.new(profile)
+        @adapter = LegacySerializer::Serializer::Adapter.new(@serializer)
+      end
+
+      def test_serializable_hash_is_abstract_method
+        assert_raises(NotImplementedError) do
+          @adapter.serializable_hash(only: [:name])
+        end
+      end
+
+      def test_serializer
+        assert_equal @serializer, @adapter.serializer
+      end
+
+      def test_adapter_class_for_known_adapter
+        klass = LegacySerializer::Serializer::Adapter.adapter_class(:json_api)
+        assert_equal LegacySerializer::Serializer::Adapter::JsonApi, klass
+      end
+
+      def test_adapter_class_for_unknown_adapter
+        klass = LegacySerializer::Serializer::Adapter.adapter_class(:json_simple)
+        assert_nil klass
+      end
+
+      def test_create_adapter
+        adapter = LegacySerializer::Serializer::Adapter.create(@serializer)
+        assert_equal LegacySerializer::Serializer::Adapter::Json, adapter.class
+      end
+
+      def test_create_adapter_with_override
+        adapter = LegacySerializer::Serializer::Adapter.create(@serializer, { adapter: :json_api})
+        assert_equal LegacySerializer::Serializer::Adapter::JsonApi, adapter.class
+      end
+    end
+  end
+end

--- a/test/array_serializer_test.rb
+++ b/test/array_serializer_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+module LegacySerializer
+  class Serializer
+    class ArraySerializerTest < Minitest::Test
+      def setup
+        @comment = Comment.new
+        @post = Post.new
+        @serializer = ArraySerializer.new([@comment, @post])
+      end
+
+      def test_respond_to_each
+        assert_respond_to @serializer, :each
+      end
+
+      def test_each_object_should_be_serialized_with_appropriate_serializer
+        serializers =  @serializer.to_a
+
+        assert_kind_of CommentSerializer, serializers.first
+        assert_kind_of Comment, serializers.first.object
+
+        assert_kind_of PostSerializer, serializers.last
+        assert_kind_of Post, serializers.last.object
+      end
+    end
+  end
+end

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -1,0 +1,111 @@
+class Model
+  def initialize(hash={})
+    @attributes = hash
+  end
+
+  def read_attribute_for_serialization(name)
+    if name == :id || name == 'id'
+      id
+    else
+      @attributes[name]
+    end
+  end
+
+  def id
+    @attributes[:id] || @attributes['id'] || object_id
+  end
+
+  def method_missing(meth, *args)
+    if meth.to_s =~ /^(.*)=$/
+      @attributes[$1.to_sym] = args[0]
+    elsif @attributes.key?(meth)
+      @attributes[meth]
+    else
+      super
+    end
+  end
+end
+
+class Profile < Model
+end
+
+class ProfileSerializer < LegacySerializer::Serializer
+  attributes :name, :description
+
+  urls :posts, :comments
+end
+
+class ProfilePreviewSerializer < LegacySerializer::Serializer
+  attributes :name
+
+  urls :posts, :comments
+end
+
+Post = Class.new(Model)
+Comment = Class.new(Model)
+Author = Class.new(Model)
+Bio = Class.new(Model)
+Blog = Class.new(Model)
+Role = Class.new(Model)
+Like = Class.new(Model) do
+  def self.serializer_class
+    RetweetSerializer
+  end
+end
+
+RetweetSerializer = Class.new(LegacySerializer::Serializer) do
+  attributes :date
+end
+
+PostSerializer = Class.new(LegacySerializer::Serializer) do
+  attributes :title, :body, :id
+
+  has_many :comments
+  belongs_to :author
+  url :comments
+end
+
+CommentSerializer = Class.new(LegacySerializer::Serializer) do
+  attributes :id, :body
+
+  belongs_to :post
+  belongs_to :author
+end
+
+AuthorSerializer = Class.new(LegacySerializer::Serializer) do
+  attributes :id, :name
+
+  has_many :posts, embed: :ids
+  has_many :roles, embed: :ids
+  belongs_to :bio
+end
+
+RoleSerializer = Class.new(LegacySerializer::Serializer) do
+  attributes :id, :name
+
+  belongs_to :author
+end
+
+BioSerializer = Class.new(LegacySerializer::Serializer) do
+  attributes :id, :content
+
+  belongs_to :author
+end
+
+BlogSerializer = Class.new(LegacySerializer::Serializer) do
+  attributes :id, :name
+
+  belongs_to :writer
+  has_many :articles
+end
+
+PaginatedSerializer = Class.new(LegacySerializer::Serializer::ArraySerializer) do
+  def json_key
+    'paginated'
+  end
+end
+
+AlternateBlogSerializer = Class.new(LegacySerializer::Serializer) do
+  attribute :id
+  attribute :name, key: :title
+end

--- a/test/serializers/adapter_for_test.rb
+++ b/test/serializers/adapter_for_test.rb
@@ -1,0 +1,50 @@
+module LegacySerializer
+  class Serializer
+    class AdapterForTest < Minitest::Test
+      def setup
+        @previous_adapter = LegacySerializer::Serializer.config.adapter
+      end
+
+      def teardown
+        LegacySerializer::Serializer.config.adapter = @previous_adapter
+      end
+
+      def test_returns_default_adapter
+        adapter = LegacySerializer::Serializer.adapter
+        assert_equal LegacySerializer::Serializer::Adapter::Json, adapter
+      end
+
+      def test_overwrite_adapter_with_symbol
+        LegacySerializer::Serializer.config.adapter = :null
+
+        adapter = LegacySerializer::Serializer.adapter
+        assert_equal LegacySerializer::Serializer::Adapter::Null, adapter
+      ensure
+
+      end
+
+      def test_overwrite_adapter_with_class
+        LegacySerializer::Serializer.config.adapter = LegacySerializer::Serializer::Adapter::Null
+
+        adapter = LegacySerializer::Serializer.adapter
+        assert_equal LegacySerializer::Serializer::Adapter::Null, adapter
+      end
+
+      def test_raises_exception_if_invalid_symbol_given
+        LegacySerializer::Serializer.config.adapter = :unknown
+
+        assert_raises ArgumentError do
+          LegacySerializer::Serializer.adapter
+        end
+      end
+
+      def test_raises_exception_if_it_does_not_know_hot_to_infer_adapter
+        LegacySerializer::Serializer.config.adapter = 42
+
+        assert_raises ArgumentError do
+          LegacySerializer::Serializer.adapter
+        end
+      end
+    end
+  end
+end

--- a/test/serializers/associations_test.rb
+++ b/test/serializers/associations_test.rb
@@ -1,0 +1,82 @@
+require 'test_helper'
+
+module LegacySerializer
+  class Serializer
+    class AssociationsTest < Minitest::Test
+      class Model
+        def initialize(hash={})
+          @attributes = hash
+        end
+
+        def read_attribute_for_serialization(name)
+          @attributes[name]
+        end
+
+        def method_missing(meth, *args)
+          if meth.to_s =~ /^(.*)=$/
+            @attributes[$1.to_sym] = args[0]
+          elsif @attributes.key?(meth)
+            @attributes[meth]
+          else
+            super
+          end
+        end
+      end
+
+
+      def setup
+        @author = Author.new(name: 'Steve K.')
+        @author.bio = nil
+        @author.roles = []
+        @post = Post.new({ title: 'New Post', body: 'Body' })
+        @comment = Comment.new({ id: 1, body: 'ZOMG A COMMENT' })
+        @post.comments = [@comment]
+        @comment.post = @post
+        @comment.author = nil
+        @post.author = @author
+        @author.posts = [@post]
+
+        @author_serializer = AuthorSerializer.new(@author)
+        @comment_serializer = CommentSerializer.new(@comment)
+      end
+
+      def test_has_many
+        assert_equal(
+          { posts: { type: :has_many, options: { embed: :ids } },
+            roles: { type: :has_many, options: { embed: :ids } },
+            bio: { type: :belongs_to, options: {} } },
+          @author_serializer.class._associations
+        )
+        @author_serializer.each_association do |name, serializer, options|
+          if name == :posts
+            assert_equal({embed: :ids}, options)
+            assert_kind_of(LegacySerializer::Serializer.config.array_serializer, serializer)
+          elsif name == :bio
+            assert_equal({}, options)
+            assert_nil serializer
+          elsif name == :roles
+            assert_equal({embed: :ids}, options)
+            assert_kind_of(LegacySerializer::Serializer.config.array_serializer, serializer)
+          else
+            flunk "Unknown association: #{name}"
+          end
+        end
+      end
+
+      def test_has_one
+        assert_equal({post: {type: :belongs_to, options: {}}, :author=>{:type=>:belongs_to, :options=>{}}}, @comment_serializer.class._associations)
+        @comment_serializer.each_association do |name, serializer, options|
+          if name == :post
+            assert_equal({}, options)
+            assert_kind_of(PostSerializer, serializer)
+          elsif name == :author
+            assert_equal({}, options)
+            assert_nil serializer
+          else
+            flunk "Unknown association: #{name}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/serializers/attribute_test.rb
+++ b/test/serializers/attribute_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+module LegacySerializer
+  class Serializer
+    class AttributeTest < Minitest::Test
+      def setup
+        @blog = Blog.new({ id: 1, name: 'AMS Hints' })
+        @blog_serializer = AlternateBlogSerializer.new(@blog)
+      end
+
+      def test_attributes_definition
+        assert_equal([:id, :title],
+                     @blog_serializer.class._attributes)
+      end
+
+      def test_json_serializable_hash
+        adapter = LegacySerializer::Serializer::Adapter::Json.new(@blog_serializer)
+        assert_equal({:id=>1, :title=>"AMS Hints"}, adapter.serializable_hash)
+      end
+    end
+  end
+end
+

--- a/test/serializers/attributes_test.rb
+++ b/test/serializers/attributes_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+module LegacySerializer
+  class Serializer
+    class AttributesTest < Minitest::Test
+      def setup
+        @profile = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
+        @profile_serializer = ProfileSerializer.new(@profile)
+      end
+
+      def test_attributes_definition
+        assert_equal([:name, :description],
+                     @profile_serializer.class._attributes)
+      end
+    end
+  end
+end
+

--- a/test/serializers/configuration_test.rb
+++ b/test/serializers/configuration_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+module LegacySerializer
+  class Serializer
+    class ConfigurationTest < Minitest::Test
+      def test_array_serializer
+        assert_equal LegacySerializer::Serializer::ArraySerializer, LegacySerializer::Serializer.config.array_serializer
+      end
+
+      def test_default_adapter
+        assert_equal :json, LegacySerializer::Serializer.config.adapter
+      end
+    end
+  end
+end

--- a/test/serializers/serializer_for_test.rb
+++ b/test/serializers/serializer_for_test.rb
@@ -1,0 +1,77 @@
+require 'test_helper'
+
+module LegacySerializer
+  class Serializer
+    class SerializerForTest < Minitest::Test
+      class ArraySerializerTest < Minitest::Test
+        def setup
+          @array = [1, 2, 3]
+          @previous_array_serializer = LegacySerializer::Serializer.config.array_serializer
+        end
+
+        def teardown
+          LegacySerializer::Serializer.config.array_serializer = @previous_array_serializer
+        end
+
+        def test_serializer_for_array
+          serializer = LegacySerializer::Serializer.serializer_for(@array)
+          assert_equal LegacySerializer::Serializer.config.array_serializer, serializer
+        end
+
+        def test_overwritten_serializer_for_array
+          new_array_serializer = Class.new
+          LegacySerializer::Serializer.config.array_serializer = new_array_serializer
+          serializer = LegacySerializer::Serializer.serializer_for(@array)
+          assert_equal new_array_serializer, serializer
+        end
+      end
+
+      class SerializerTest <  Minitest::Test
+        class MyProfile < Profile
+        end
+
+        class Star < Like
+          def self.serializer_class
+            SuperStarSerializer
+          end
+        end
+
+        class SuperStarSerializer < LegacySerializer::Serializer
+          attributes :user_id
+        end
+
+        def setup
+          @profile = Profile.new
+          @my_profile = MyProfile.new
+          @model = ::Model.new
+        end
+
+        def test_serializer_for_existing_serializer
+          serializer = LegacySerializer::Serializer.serializer_for(@profile)
+          assert_equal ProfileSerializer, serializer
+        end
+
+        def test_serializer_for_not_existing_serializer
+          serializer = LegacySerializer::Serializer.serializer_for(@model)
+          assert_equal nil, serializer
+        end
+
+        def test_serializer_inherited_serializer
+          serializer = LegacySerializer::Serializer.serializer_for(@my_profile)
+          assert_equal ProfileSerializer, serializer
+        end
+
+        def test_serializer_with_serializer_class_method
+          serializer = LegacySerializer::Serializer.serializer_for(Like.new)
+          assert_equal RetweetSerializer, serializer
+        end
+
+        def test_inherited_serializer_with_overriden_serializer_class_method
+          serializer = LegacySerializer::Serializer.serializer_for(Star.new)
+          assert_equal SuperStarSerializer, serializer
+        end
+
+      end
+    end
+  end
+end

--- a/test/serializers/urls_test.rb
+++ b/test/serializers/urls_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+module LegacySerializer
+  class Serializer
+    class UrlsTest < Minitest::Test
+
+      def setup
+        @profile = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
+        @post = Post.new({ title: 'New Post', body: 'Body' })
+        @comment = Comment.new({ id: 1, body: 'ZOMG A COMMENT' })
+        @post.comments = [@comment]
+
+        @profile_serializer = ProfileSerializer.new(@profile)
+        @post_serializer = PostSerializer.new(@post)
+      end
+
+      def test_urls_definition
+        assert_equal([:posts, :comments], @profile_serializer.class._urls)
+      end
+
+      def test_url_definition
+        assert_equal([:comments], @post_serializer.class._urls)
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,33 @@
+require "bundler/setup"
+
+require 'rails'
+require 'action_controller'
+require 'action_controller/test_case'
+require "active_support/json"
+require 'minitest/autorun'
+# Ensure backward compatibility with Minitest 4
+Minitest::Test = MiniTest::Unit::TestCase unless defined?(Minitest::Test)
+
+require "legacy_serializer"
+
+require 'fixtures/poro'
+
+module TestHelper
+  Routes = ActionDispatch::Routing::RouteSet.new
+  Routes.draw do
+    get ':controller(/:action(/:id))'
+    get ':controller(/:action)'
+  end
+
+  ActionController::Base.send :include, Routes.url_helpers
+end
+
+ActionController::TestCase.class_eval do
+  def setup
+    @routes = TestHelper::Routes
+  end
+end
+
+def def_serializer(&block)
+  Class.new(LegacySerializer::Serializer, &block)
+end


### PR DESCRIPTION
I restored the old specs and added a spec for the case where the model define a `serializer_class`. From there, I could be able to easily add association overriding.
